### PR TITLE
Shortcuts in some special commoon folders caused UnauthorizedException

### DIFF
--- a/Shellify/ShellLinkFile.cs
+++ b/Shellify/ShellLinkFile.cs
@@ -162,7 +162,7 @@ namespace Shellify
 		{
 			var result = new ShellLinkFile();
 			
-			using var stream = new FileStream(filename, FileMode.Open);
+			using var stream = File.OpenRead(filename);
 			using var binaryReader = new BinaryReader(stream);
 			
 			var reader = new ShellLinkFileHandler(result);


### PR DESCRIPTION
Solved bug that links in special common folders (like ProgramData) could not be accessed.